### PR TITLE
Remove concurrency group from tox workflow

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -8,12 +8,6 @@ on:
         description: The ref to build.
         required: true
 
-# Use the head ref for workflow concurrency, with cancellation
-# This should mean that any previous workflows for a PR get cancelled when a new commit is pushed
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     name: Tox unit tests and linting


### PR DESCRIPTION
As this is called from the test-pr workflow, allow test-pr to handle the concurrency.