### PR TITLE
Wait for Kubernetes nodes and addons

### DIFF
--- a/Azimuth/kubernetes_clusters.py
+++ b/Azimuth/kubernetes_clusters.py
@@ -261,6 +261,71 @@ class KubernetesClusterKeywords:
         return data["kubeconfig"]
 
     @keyword
+    def wait_for_kubernetes_cluster_addons_status(
+        self,
+        id: str,  # noqa: A002
+        target_status: str,
+        interval: int = 15,
+    ) -> dict[str, t.Any]:
+        """
+        Waits for the specified cluster to reach the target status before returning it.
+        """
+        return util.wait_for_many_resource_status(
+            self._resource,
+            id,
+            "addons",
+            target_status,
+            {"Installing", "Preparing", "Pending", "Upgrading", "Uninstalling"},
+            "error_message",
+            interval,
+        )
+
+    @keyword
+    def wait_for_kubernetes_cluster_addons_deployed(
+        self,
+        id: str,  # noqa: A002
+        interval: int = 15,
+    ) -> dict[str, t.Any]:
+        """
+        Waits for the cluster addons to be status Ready
+        before returning the cluster.
+        """
+        return self.wait_for_kubernetes_cluster_addons_status(id, "Deployed", interval)
+
+    @keyword
+    def wait_for_kubernetes_cluster_nodes_status(
+        self,
+        id: str,  # noqa: A002
+        target_status: str,
+        interval: int = 15,
+    ) -> dict[str, t.Any]:
+        """
+        Waits for all nodes in the specified cluster to reach the target
+        status before returning it.
+        """
+        return util.wait_for_many_resource_status(
+            self._resource,
+            id,
+            "nodes",
+            target_status,
+            {"Provisioning", "Pending", "Deleting", "Unhealthy", "Unknown"},
+            "error_message",
+            interval,
+        )
+
+    @keyword
+    def wait_for_kubernetes_cluster_nodes_ready(
+        self,
+        id: str,  # noqa: A002
+        interval: int = 15,
+    ) -> dict[str, t.Any]:
+        """
+        Waits for all cluster nodes to be status Ready before
+        returning the cluster.
+        """
+        return self.wait_for_kubernetes_cluster_nodes_status(id, "Ready", interval)
+
+    @keyword
     def wait_for_kubernetes_cluster_status(
         self,
         id: str,  # noqa: A002

--- a/Azimuth/kubernetes_clusters.py
+++ b/Azimuth/kubernetes_clusters.py
@@ -623,6 +623,48 @@ class KubernetesClusterKeywords:
         return output_path
 
     @keyword
+    def get_nodes_for_kubernetes_cluster(
+        self,
+        id: str,  # noqa: A002
+        *,
+        output_path="node_status.json",
+    ):
+        """
+        Retrieves status for all nodes from the specified cluster.
+
+        Runs ``kubectl get nodes -o json`` and saves the output as
+        a JSON file.
+
+        Returns the path to the created JSON file.
+        """
+        with self._kubeconfig_for_cluster(id) as kubeconfig:
+            proc = subprocess.run(
+                [
+                    "kubectl",
+                    "--kubeconfig",
+                    kubeconfig,
+                    "get",
+                    "nodes",
+                    "-o",
+                    "json",
+                ],
+                capture_output=True,
+            )
+        if proc.returncode != 0:
+            logger.info("kubectl get nodes command failed")
+            logger.info(proc.stderr)
+        assert proc.returncode == 0, "kubectl get nodes command failed"
+        logger.info(proc.stdout)
+        output = proc.stdout
+        if isinstance(output, bytes):
+            output = output.decode()
+        data = json.loads(output)
+        with open(output_path, "w") as f:
+            json.dump(data, f, indent=2)
+        logger.info(f"Node information saved to {output_path}")
+        return output_path
+
+    @keyword
     def get_helm_releases_for_kubernetes_cluster(
         self,
         id: str,  # noqa: A002

--- a/Azimuth/kubernetes_clusters.py
+++ b/Azimuth/kubernetes_clusters.py
@@ -14,7 +14,7 @@ import typing as t
 from robot.api import logger
 from robot.api.deco import keyword
 
-from . import util
+from . import openstack_cloud, util
 
 
 @dataclasses.dataclass(frozen=True)
@@ -704,3 +704,28 @@ class KubernetesClusterKeywords:
             json.dump(data, f, indent=2)
         logger.info(f"Helm releases saved to {output_path}")
         return output_path
+
+    @keyword
+    def get_console_logs_for_kubernetes_cluster_nodes(
+        self,
+        id: str,  # noqa: A002
+        output_prefix="console-logs",
+    ):
+        """
+        Retrieves console logs for all openstack nodes in the cluster and
+        saves the output as a text file.
+        """
+        cluster = self.fetch_kubernetes_cluster_by_id(id)
+        nodes = getattr(cluster, "nodes")
+
+        for node_name in [node["name"] for node in nodes]:
+            console_log = openstack_cloud.get_console_log_for_server(node_name)
+            if console_log:
+                output_path = f"{output_prefix}-{node_name}.log"
+                with open(output_path, "w") as f:
+                    f.write(console_log["output"])
+                    logger.info(f"Wrote log for {node_name} to {output_path}")
+            else:
+                logger.warn(
+                    f"Could not retrieve logs for {node_name}, no server exists"
+                )

--- a/Azimuth/openstack_cloud.py
+++ b/Azimuth/openstack_cloud.py
@@ -1,0 +1,17 @@
+import typing as t
+
+import openstack
+
+
+def get_console_log_for_server(server_name: str) -> dict[str, t.Any]:
+    """
+    Retrieves the console log for a specified server.
+    Returns the console output as a dict. Control characters are
+    escaped to create a valid JSON string.
+    """
+    conn = openstack.connect()
+    server = conn.compute.find_server(server_name)
+    if server:
+        return conn.compute.get_server_console_output(server)
+    else:
+        return None

--- a/Azimuth/util.py
+++ b/Azimuth/util.py
@@ -2,6 +2,7 @@ import time
 import typing as t
 
 import azimuth_sdk
+from robot.api import logger
 
 
 def wait_for_resource(
@@ -40,9 +41,57 @@ def wait_for_resource_property(
         if property_value == target_value:
             return True
         elif property_value in working_values:
+            logger.info(
+                f"{property} is {property_value} not {target_value}, waiting..."
+            )
             return False
         else:
             message = f"unexpected {property} - {property_value}"
+            error_message = getattr(instance, error_message_property, None)
+            if error_message:
+                message = f"{message} - {error_message}"
+            raise AssertionError(message)
+
+    return wait_for_resource(resource, id, predicate, interval)
+
+
+def wait_for_many_resource_status(
+    resource,
+    id: str,  # noqa: A002
+    property: str,  # noqa: A002
+    target_value: t.Any,
+    working_values: t.Collection[t.Any],
+    error_message_property: str,
+    interval: int,
+) -> dict[str, t.Any]:
+    """
+    Waits for the status field of all elements of a specified list property on
+    the instance with the given ID to reach a target value. It will only continue
+    while the status field of the property all have values in the working values
+    or are the target value.
+    """
+
+    def predicate(instance):
+        property_value = getattr(instance, property)
+        working_values.add(target_value)
+        if len(property_value) == 0:
+            logger.info(f"Property {property} has 0 elements, waiting...")
+            return False
+        if all([element["status"] == target_value for element in property_value]):
+            return True
+        elif all([element["status"] in working_values for element in property_value]):
+            failed_elements = [
+                element
+                for element in property_value
+                if element["status"] != target_value
+            ]
+            logger.info(
+                f"Property {property} statuses are not {target_value}, "
+                f"{failed_elements} waiting..."
+            )
+            return False
+        else:
+            message = f"unexpected {property} status - {property_value}"
             error_message = getattr(instance, error_message_property, None)
             if error_message:
                 message = f"{message} - {error_message}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     easysemver
     httpx
     jsonschema-default
+    openstacksdk
     robotframework-pythonlibcore
     robotframework
     selenium


### PR DESCRIPTION
We can gain more information about what things are preventing Kubernetes clusters from reporting as Ready by interrogating Addons and Nodes for their status.

Also, there may be information about why a cluster node failed to become ready in either its Kubernetes `node` object or OpenStack console log.

Add keywords for waiting for Addons and Nodes to reach their terminal states, and keywords for extracting instance console logs and Kubernetes node objects.